### PR TITLE
fixing inter-device move failed

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -173,4 +173,4 @@ echo "-----> Making cabal config available to Heroku command line"
 mv $WORKING_HOME/.cabal $BUILD_DIR
 
 echo "-----> Making cabal sandbox available to Heroku command line"
-mv $WORKING_HOME/.cabal-sandbox $BUILD_DIR
+cp -R $WORKING_HOME/.cabal-sandbox $BUILD_DIR


### PR DESCRIPTION
While deploying to heroku with this build package, I had the typical move error (inter-device move failed) for this line, so I changed into a cp -R.
The build ended up working after many many attempts. Yesod and heroku, not a match made in heaven.
