### PR TITLE
Partial support for deploying Yesod applications

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ WORKING_HOME=/app
 
 GHC_VER=7.6.3
 CABAL_VER=1.18.0.2
-CLEAR_CACHE=true
+CLEAR_CACHE=false
 S3=https://s3.amazonaws.com/heroku-ghc
 
 if $CLEAR_CACHE ; then


### PR DESCRIPTION
When deploying a blank Yesod (1.2.4) application, the `libpcre` library is missing, so I've added this into the buildpack.

However, unfortunately this still does not deploy correctly due to a problem with yesod-core:

```
Building yesod-core-1.2.6.5...
Failed to install yesod-core-1.2.6.5
Last 10 lines of the build log ( /app/.cabal-sandbox/logs/yesod-core-1.2.6.5.log ):
Loading package zlib-conduit-1.0.0 ... linking ... done.
Loading package wai-extra-2.0.1.2 ... linking ... done.
Loading package syb-0.4.1 ... linking ... done.
Loading package aeson-0.6.2.1 ... linking ... done.
Loading package process-1.1.0.2 ... linking ... done.
Loading package system-filepath-0.4.9 ... linking ... done.
Loading package system-fileio-0.3.12 ... linking ... done.
Loading package shakespeare-1.2.0.4 ... linking ... done.
Loading package shakespeare-js-1.2.0.2 ... linking ... ghc: /app/.cabal-sandbox/lib/x86_64-linux-ghc-7.6.3/shakespeare-js-1.2.0.2/HSshakespeare-js-1.2.0.2.o: unknown symbol `aesonzm0zi7zi0zi0_DataziAesonziEncode_encodeToTextBuilder_closure'
ghc: unable to load package `shakespeare-js-1.2.0.2'
cabal: Error: some packages failed to install:
circuithub-quoting-0.0.0 depends on yesod-core-1.2.6.5 which failed to
install.
yesod-1.2.4 depends on yesod-core-1.2.6.5 which failed to install.
yesod-auth-1.2.5.3 depends on yesod-core-1.2.6.5 which failed to install.
yesod-core-1.2.6.5 failed during the building phase. The exception was:
ExitFailure 1
yesod-form-1.3.4.4 depends on yesod-core-1.2.6.5 which failed to install.
yesod-persistent-1.2.2.1 depends on yesod-core-1.2.6.5 which failed to
install.
yesod-static-1.2.2.1 depends on yesod-core-1.2.6.5 which failed to install.
```
