### PR TITLE
Compile binaries to dist/build, not sandbox folder

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -157,7 +157,8 @@ echo "-----> Getting newest list of cabal packages"
 cabal update
 
 echo "-----> Installing user application"
-cabal install -j --disable-library-profiling --disable-executable-profiling --disable-shared
+cabal configure --disable-library-profiling --disable-executable-profiling --disable-shared
+cabal build -j
 
 echo "-----> Caching latest cabal sandbox"
 rm -fr $CACHE_DIR/.cabal-sandbox


### PR DESCRIPTION
Prevents binary recompilation on server restart as noted in #12. However there is still unnecessary linking on every restart. While we figure out the linking I'm merging this fix because it's better than nothing.
