### PR TITLE
Add a flag that can be used to clear the buildpack cache

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,6 +11,7 @@ CABAL_VER=1.18.0.2
 S3=https://s3.amazonaws.com/heroku-ghc
 
 if $CLEAR_BUILDPACK_CACHE ; then
+  echo "-----> Clearing the buildpack cache"
   rm -fr $CACHE_DIR/
 fi
 


### PR DESCRIPTION
In reference to issue #13.

`heroku config:set CLEAR_BUILDPACK_CACHE=` can be added to the heroku environment to clear the build cache.
Also requires `user-env-compile` to be enabled (via `heroku labs:enable user-env-compile`) in order to use the user environment in the buildpack.
- https://devcenter.heroku.com/articles/config-vars#setting-up-config-vars-for-a-deployed-application
- https://devcenter.heroku.com/articles/labs-user-env-compile
