### PR TITLE
Fix check for $CLEAR_BUILDCACHE_CACHE

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,7 @@ GHC_VER=7.6.3
 CABAL_VER=1.18.0.2
 S3=https://s3.amazonaws.com/heroku-ghc
 
-if $CLEAR_BUILDPACK_CACHE ; then
+if [[ $CLEAR_BUILDPACK_CACHE -eq 1 ]] ; then
   echo "-----> Clearing the buildpack cache"
   rm -fr $CACHE_DIR/
 fi


### PR DESCRIPTION
Previously, it would just clear it when I had not set that environment variable. I think that this solves the problem; does it look all right?
