### PR TITLE
Add note on specifying UTF-8 character encoding in Haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ s3cmd-1.5.0-alpha1/s3cmd put heroku-ghc-[VERSION].tar.gz s3://[BUCKET]
 s3cmd-1.5.0-alpha1/s3cmd put heroku-cabal-install-[VERSION].tar.gz s3://[BUCKET]
 ```
 
+### Addendum: Character encoding on Heroku
+
+Haskell uses the default system character encoding unless you specify otherwise.
+You probably want this to be UTF-8, so to avoid problems set the following
+option:
+
+    heroku config:add LANG=en_US.UTF-8
+
 ### Thanks
 
 Thanks to Brian McKenna and others for their work on


### PR DESCRIPTION
When Haskell reads from System.IO it defaults to using the character encoding specified by the operating system [1]. Unfortunately it seems Heroku doesn't specify UTF-8 by default, so you can see encoding issues if you don't set an option in your VM. Using this command, which is also specified on the SBCL buildpack README [2], fixed an encoding error that I experienced when reading UTF-8 files from the filesystem in a Haskell app. I think it's a good idea to include it in the README until Heroku defaults to UTF-8 at the OS level for character encoding.

I'll also forward this commit to Heroku support to see if they can shed some more light on their reasoning for not specifying character encoding since the default doesn't seem particularly intuitive or helpful for most applications.

1 - http://stackoverflow.com/questions/5286860/how-does-ghc-haskell-decide-what-character-encoding-its-going-to-decode-encode
2 - https://github.com/jsmpereira/heroku-buildpack-cl
