### PR TITLE
Pass --reorder-goals to "cabal install"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -177,7 +177,7 @@ cabal update
 
 echo "-----> Installing user application"
 cabal configure --disable-library-profiling --disable-executable-profiling --disable-shared
-cabal install --only-dependencies
+cabal install --only-dependencies --reorder-goals
 cabal build -j
 
 # Set context environment variables.


### PR DESCRIPTION
I'm submitting this pull request mostly for discussion.  The change is required to make my app (a moderate-complexity Yesod app) build, but I'm not entirely sure it would be consequence-free for other apps.

Maybe it would make sense to allow user apps to specify custom options to cabal?  Though I don't know what mechanism to use for that now that `user-env-compile` is being removed (so a config variable will no longer work).
## More detail

Tweaks the cabal dependency resolution heuristics in some undocumented way that makes cabal more likely to solve Yesod dependencies.  (Without this you see odd errors like yesod-platform getting rejected because it depends on a conflicting version of, say, aeson, than your app does, even though your .cabal file doesn't actually specify which version of aeson, and the whole point of yesod-platform was to lock it to a version that would work.)

This feels like black magic, but it's [recommended by the Yesod documentation](http://www.yesodweb.com/page/quickstart) :(
