### PR TITLE
Permit subdirectory libs and includes

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -98,15 +98,13 @@ function install_prebuilt_library {
       make install
       # Remove unnecessary files
       rm -rf $CACHE_DIR/$NAME-$VER/build
-      for dir in $CACHE_DIR/$NAME-$VER/ghc-libs/*/ ; do rm -rf $dir ; done
-      for dir in $CACHE_DIR/$NAME-$VER/ghc-includes/*/ ; do rm -rf $dir ; done
       find $CACHE_DIR/$NAME-$VER/ghc-libs -xtype f -not -name '*.so*' -print0| xargs -0 -r rm
       find $CACHE_DIR/$NAME-$VER/ghc-includes -xtype f -not -name '*.h*' -print0| xargs -0 -r rm
     fi
   fi
   echo "-----> Restoring $NAME files from cache"
-  find $CACHE_DIR/$NAME-$VER/ghc-libs/ -xtype f -exec cp -P '{}' $WORKING_HOME/vendor/ghc-libs/ \;         # alternate/quiet form of: cp -P $CACHE_DIR/$NAME-$VER/ghc-libs/* $WORKING_HOME/vendor/ghc-libs/
-  find $CACHE_DIR/$NAME-$VER/ghc-includes/ -xtype f -exec cp -P '{}' $WORKING_HOME/vendor/ghc-includes/ \; # alternate/quiet form of: cp -P $CACHE_DIR/$NAME-$VER/ghc-includes/* $WORKING_HOME/vendor/ghc-includes/
+  find $CACHE_DIR/$NAME-$VER/ghc-libs/ -exec cp -rP '{}' $WORKING_HOME/vendor/ghc-libs/ \;         # alternate/quiet form of: cp -P $CACHE_DIR/$NAME-$VER/ghc-libs/* $WORKING_HOME/vendor/ghc-libs/
+  find $CACHE_DIR/$NAME-$VER/ghc-includes/ -exec cp -rP '{}' $WORKING_HOME/vendor/ghc-includes/ \; # alternate/quiet form of: cp -P $CACHE_DIR/$NAME-$VER/ghc-includes/* $WORKING_HOME/vendor/ghc-includes/
 }
 
 # Usage: $ set-env key value


### PR DESCRIPTION
It seems that the buildpack expects all libs and includes to be single, unnested files. This assumption is not always borne out. For example, the text-icu package depends on external icu libraries which have have includes like `include/unicode/ubrk.h`.
