### PR TITLE
Detect only returns success if cabal file exists

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-echo Haskell; exit 0
+if [ -n "$(find "$1" -maxdepth 1 -name '*.cabal' -print -quit)" ]; then
+  echo "Haskell" && exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
I'm experimenting with the dokku project and since detect always returns success it's always selected buildpack for deploying no matter if it's a Haskell project or not. This patch addresses the issue. 
