### PR TITLE
Upgrade pcre to 8.35

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -161,8 +161,8 @@ if [ -e $CACHE_DIR/libffi-3.0.13/libs ]; then
   rm -rf $CACHE_DIR/libffi-3.0.13/libs
 fi
 
-LIBPCRE_URL="http://iweb.dl.sourceforge.net/project/pcre/pcre/8.34/pcre-8.34.tar.gz"
-install_prebuilt_library "libpcre" "8.34" $LIBPCRE_URL "pcre-8.34" "--enable-silent-rules --enable-static=no --disable-cpp"
+LIBPCRE_URL="http://iweb.dl.sourceforge.net/project/pcre/pcre/8.35/pcre-8.35.tar.gz"
+install_prebuilt_library "libpcre" "8.35" $LIBPCRE_URL "pcre-8.35" "--enable-silent-rules --enable-static=no --disable-cpp"
 
 install_prebuilt "happy" "1.19.2"
 install_prebuilt "alex" "3.1.3"


### PR DESCRIPTION
Not sure if it'll break older versions of pcre-light, it works perfectly with pcre-light-0.4 anyway
