### PR TITLE
Cabal run sometimes breaks (The version of Cabal being used has changed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ snap init barebones
 
 # Tell Heroku how to start the server
 
-echo 'web: cabal run -- -p $PORT' > Procfile
+echo 'web: ./dist/build/myapp/myapp -p $PORT' > Procfile
 
 # Create a git repo and deploy!
 


### PR DESCRIPTION
As I've mentioned in #42 I sometimes get this error when running `cabal run`

```
cabal: You need to re-run the 'configure' command. The version of Cabal being
used has changed (was Cabal-1.18.1.2, now Cabal-1.18.1).
```

I'm not sure if this is the best fix to be honest, but since the app should already be built in the compile step of the buildpack, it should be ok to simply run it directly. (I think that perhaps `cabal run` detects changes in the file's timestamps and tries to rebuild them unnecessarily.)
