### PR TITLE
Detect failures and stop the deploy

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,6 +1,9 @@
 #!/bin/bash
 # bin/compile <build-dir> <cache-dir> <env-dir>
 
+set -e            # fail fast
+set -o pipefail   # do not ignore exit codes when piping output
+
 # Heroku-provided params
 BUILD_DIR="$1"
 CACHE_DIR="$2"


### PR DESCRIPTION
Fixes #46.

It worked for the failing and successful builds that I tried. My only worry is that some minor step might fail during a build and make the whole thing fail, but time will tell.
