### PR TITLE
Guard script against nonzero cabal configure code

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -231,7 +231,7 @@ echo "-----> Getting newest list of cabal packages"
 cabal update
 
 echo "-----> Installing user application"
-cabal configure --disable-library-profiling --disable-executable-profiling --disable-shared
+cabal configure --disable-library-profiling --disable-executable-profiling --disable-shared || true
 cabal install --only-dependencies --reorder-goals
 cabal build -j
 


### PR DESCRIPTION
Fixes #50 

`cabal configure` returns nonzero when dependencies are not installed. However our next step in the buildpack will be to install missing stuff, so this is no cause for alarm. The change at 12ffcdcc56fec979abf4cce3d06acb2cf293648c made the script too touchy about failing commands.
