### PR TITLE
Add error handling to move and copy cabal directory

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -252,7 +252,9 @@ rm -fr $CACHE_DIR/download
 
 echo "-----> Caching latest cabal sandbox"
 rm -fr $CACHE_DIR/.cabal-sandbox
-cp -R $WORKING_HOME/.cabal-sandbox $CACHE_DIR
+if [ -d $WORKING_HOME/.cabal-sandbox ]; then
+  cp -R $WORKING_HOME/.cabal-sandbox $CACHE_DIR
+fi
 
 echo "-----> Making GHC binaries available to Heroku command line"
 mkdir -p $BUILD_DIR/vendor
@@ -263,7 +265,12 @@ mv $WORKING_HOME/vendor/ghc-$GHC_VER $BUILD_DIR/vendor
 mv $WORKING_HOME/vendor/cabal-install-$CABAL_VER $BUILD_DIR/vendor
 
 echo "-----> Making cabal config available to Heroku command line"
-mv $WORKING_HOME/.cabal $BUILD_DIR
+if [ -d $WORKING_HOME/.cabal ]; then
+  mv $WORKING_HOME/.cabal $BUILD_DIR
+fi
 
 echo "-----> Making cabal sandbox available to Heroku command line"
-cp -R $WORKING_HOME/.cabal-sandbox $BUILD_DIR
+if [ -d $WORKING_HOME/.cabal-sandbox ]; then
+  cp -R $WORKING_HOME/.cabal-sandbox $BUILD_DIR
+fi
+


### PR DESCRIPTION
To avoid error while deploying if a project has no .cabal directory.
