### PR TITLE
Preserve existing PATH from other buildpacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,6 +30,7 @@ export_env_dir() {
       export "$e=$(cat $env_dir/$e)"
       :
     done
+    export "PATH=$(cat $env_dir/PATH):$PATH"
   fi
 }
 


### PR DESCRIPTION
When using heroku-buildpack-multi, other buildpacks may generate binaries and add them to the PATH. This prevents those changes from being lost.
