### PR TITLE
Hacky fix for anvil build failure because of alex/happy

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -72,6 +72,10 @@ function install_prebuilt {
   PKG=$1
   VER=$2
 
+  if [ -e $CACHE_DIR/$PKG -a ! -d $CACHE_DIR/$PKG ]; then
+    echo "-----> Removing mysterious package file for $PKG"
+    rm $CACHE_DIR/$PKG
+  fi
   if [ ! -e $CACHE_DIR/$PKG ]; then
     PKG_URL=$PREBUILT/heroku-$PKG-$VER.tar.gz
     if curl --output /dev/null --silent --head --fail $PKG_URL; then


### PR DESCRIPTION
This is more of a bug report, I don't really propose that this commit is a good change.

I kept running into the following error when building via anvil:

```
puzzle-draw-snap robert$ heroku build -r -b https://github.com/begriffs/heroku-buildpack-ghc.git
Checking for app files to sync... done, 12 files needed
Uploading: 100.0% (ETA: 0s)
Launching build process... done 
Preparing app for compilation... done 
Fetching buildpack... done 
Detecting buildpack... done, Haskell 
Fetching cache... done 
Compiling app... 
  Linking libncurses.so in an accessible place
  Restoring libffi files from cache
  Installing prebuilt libpcre-8.35 into cache
######################################################################## 100.0%
  Restoring libpcre files from cache
  Installing prebuilt libgmp-6.0.0a into cache
######################################################################## 100.0%
  Restoring libgmp files from cache
  Installing prebuilt GHC 7.8.3
######################################################################## 100.0%
  Caching GHC 7.8.3 binaries
  Restoring cached happy
cp: cannot stat `/tmp/cache_lHNed/happy/.': Not a directory
ERROR: Build failed, exited 1
```

For some reasone, `$CACHE_DIR/happy` exists but is not a directory. The build script sees it exists and assumes it's a good cache directory, then fails trying to copy it.

The fix here deletes the file if it exists and is not a directory. This works; the same problem shows up with `alex`.

```
Compiling app... 
  Linking libncurses.so in an accessible place
  Restoring libffi files from cache
  Installing prebuilt libpcre-8.35 into cache
######################################################################## 100.0%
  Restoring libpcre files from cache
  Installing prebuilt libgmp-6.0.0a into cache
######################################################################## 100.0%
  Restoring libgmp files from cache
  Installing prebuilt GHC 7.8.3
######################################################################## 100.0%
  Caching GHC 7.8.3 binaries
  Removing mysterious package file for happy
  Downloading and caching prebuilt happy binaries and shared data
######################################################################## 100.0%
  Installing happy
  Removing mysterious package file for alex
  Downloading and caching prebuilt alex binaries and shared data
######################################################################## 100.0%
  Installing alex
  Downloading and caching prebuilt cpphs binaries and shared data
######################################################################## 100.0%
  Installing cpphs
  Installing prebuilt cabal-install 1.20.0.2
######################################################################## 100.0%
  Caching cabal 1.20.0.2 binaries
```
