### PR TITLE
Cedar-14 stack in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ echo "dist\n.cabal-sandbox\ncabal.sandbox.config" > .gitignore
 git add *
 git commit -m 'Initial commit'
 
-heroku create --stack=cedar --buildpack https://github.com/begriffs/heroku-buildpack-ghc.git
+heroku create --stack=cedar-14 --buildpack https://github.com/begriffs/heroku-buildpack-ghc.git
 git push heroku master
 ```
 


### PR DESCRIPTION
The old Cedar stack is now deprecated (see https://devcenter.heroku.com/articles/stack).