### PR TITLE
looks like an interpolation problem when adding the PATH setting code…

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -266,7 +266,7 @@ cabal install --only-dependencies --reorder-goals --disable-library-profiling --
 cabal build -j
 
 # Set context environment variables.
-set-env PATH "/app/vendor/ghc-$GHC_VER/bin:/app/vendor/ghc-utils/bin:/app/vendor/cabal-install-$CABAL_VER/bin:$PATH"
+set-env PATH "/app/vendor/ghc-$GHC_VER/bin:/app/vendor/ghc-utils/bin:/app/vendor/cabal-install-$CABAL_VER/bin"':$PATH'
 
 set-default-env LANG en_US.UTF-8
 set-default-env C_INCLUDE_PATH /app/vendor/ghc-includes:/usr/include


### PR DESCRIPTION
… to haskell.sh

it appears that set-default-env was not appropriate to use, but in the attempted to place the old path at the end of the new path that the current patch was concatenated instead of added $PATH literally to the end