### PR TITLE
Add support for running a script at the end of the compile (via POST_SCRIPT env var)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ Here are the options
   <td>Path to an executable, relative to checkout root. If present, this will be chmodded (+x) and ran before anything else.</td>
   <td></td>
 </tr>
+<tr>
+  <td>POST_SCRIPT</td>
+  <td>Path to an executable, relative to checkout root. If present, this will be chmodded (+x) and ran after anything else.</td>
+  <td></td>
+</tr>
 </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -101,10 +101,7 @@ git add cabal.config
 You can change build settings through Heroku environment variables.
 
 ```sh
-# allow the buildpack to see environment vars
-heroku labs:enable buildpack-env-arg
-
-# then set the variable of your choice
+# set the variable of your choice
 heroku config:set VARIABLE=value
 ```
 

--- a/bin/compile
+++ b/bin/compile
@@ -300,3 +300,10 @@ if [ -d $WORKING_HOME/.cabal-sandbox ]; then
   cp -R $WORKING_HOME/.cabal-sandbox $BUILD_DIR
 fi
 
+# run user post-script
+POST_SCRIPT_FULL="$BUILD_DIR/$POST_SCRIPT"
+if [ -f "$POST_SCRIPT_FULL" ]; then
+  echo "-----> Running POST_SCRIPT: $POST_SCRIPT"
+  chmod +x $POST_SCRIPT_FULL
+  $POST_SCRIPT_FULL "$BUILD_DIR" "$CACHE_DIR $ENV_DIR"
+fi


### PR DESCRIPTION
With the update to ghc 7.10 (or it's because of new dependencies of my dependencies) my slug size has passed the magic 300mb barrier. I've added a simple hack to support manually cleaning up the slug (since for my app I can live with no ghci) by copying the `PRE_SCRIPT` support to run a script at the end of the compile. It would be nice to have this handled automatically (eg #44 or #49), but this works for me and was easy to add.